### PR TITLE
Update bootBuildImage environment; don't replace it

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,10 +86,10 @@ tasks.withType(AbstractArchiveTask) {
 // See: https://candrews.integralblue.com/2022/10/improving-the-reproducibility-of-spring-boots-docker-image-builder/
 tasks.named("bootBuildImage") {
 	// See: https://paketo.io/docs/howto/java/
-	environment = [
-		// run the JLink tool and install a minimal JRE for runtime, reducing both image size and attack surface
-		"BP_JVM_JLINK_ENABLED" : "true",
-	]
+
+	// run the JLink tool and install a minimal JRE for runtime, reducing both image size and attack surface
+	environment["BPJVM_JLINK_ENABLED"] = "true"
+
 	docker {
 		// version and digest pin all image references. This ensures reproducibility.
 		// make sure to configure Renovate to keep these image references up to date.


### PR DESCRIPTION
Assigning a new value to environment replaces all mappings. By assigning to individual keys, the existing map is updated so defaults are preserved.

See: https://github.com/spring-projects/spring-boot/issues/32886