### PR TITLE
In reports, replace enabled with required

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,8 +132,8 @@ bootJar {
 
 jacocoTestReport {
 	reports {
-		html.enabled true
-		xml.enabled true
+		html.required = true
+		xml.required = true
 	}
 }
 


### PR DESCRIPTION
"enabled" is deprecated in favor of "required"

See: https://docs.gradle.org/7.5.1/dsl/org.gradle.api.reporting.Report.html#org.gradle.api.reporting.Report:enabled