### PR TITLE
Fix generateFrontendResources to dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -201,7 +201,7 @@ task npmLighthouseVersion(type: NpxTask) {
 }
 
 task generateFrontendResources(type: Copy) {
-	dependsOn npm_run_build_build
+	dependsOn npm_run_build
 	from "${frontend}/build"
 	into "$generatedFrontendResources/static"
 	outputs.dir "$generatedFrontendResources"


### PR DESCRIPTION
generateFrontendResources should depend on npm_run_build (not npm_run_build_build which is a typo / a task that doesn't exist)