### PR TITLE
Migrate to Spring Security lambda syntax

### DIFF
--- a/src/main/java/com/integralblue/demo/jumpstart/security/FixedUsernamePasswordSecurityConfiguration.java
+++ b/src/main/java/com/integralblue/demo/jumpstart/security/FixedUsernamePasswordSecurityConfiguration.java
@@ -9,6 +9,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 
+import static org.springframework.security.config.Customizer.withDefaults;
+
 /** Security configuration when using fixed username/passwords.
  *
  * This configuration should only be used for testing!
@@ -20,15 +22,14 @@ public class FixedUsernamePasswordSecurityConfiguration {
 	@Bean
 	@SuppressWarnings("PMD.SignatureDeclareThrowsException")
 	public SecurityFilterChain filterChain(final @NonNull HttpSecurity http) throws Exception {
-		http
-			.authorizeHttpRequests()
-			.anyRequest()
-			.authenticated()
-			.and()
-			.formLogin()
-			.and()
-			.httpBasic();
-		return http.build();
+		return
+			http
+			.authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests
+				.anyRequest()
+				.authenticated())
+			.formLogin(withDefaults())
+			.httpBasic(withDefaults())
+			.build();
 	}
 
 	@Bean


### PR DESCRIPTION
Spring Security 6.1 deprecates the non-lambda syntax so this migration is necessary to prepare for that update.

See: https://spring.io/blog/2019/11/21/spring-security-lambda-dsl