### PR TITLE
Use Spring Boot managed version of testcontainers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,6 @@ compileJava {
 }
 
 dependencies {
-	implementation(platform("org.testcontainers:testcontainers-bom:1.18.1"))
 	implementation "org.springframework.boot:spring-boot-starter-actuator"
 	implementation "org.springframework.boot:spring-boot-starter-data-jpa"
 	implementation "org.springframework.boot:spring-boot-starter-security"


### PR DESCRIPTION
With Spring Boot 3.1, Spring Boot’s dependency management now includes Testcontainers.

See: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.1-Release-Notes#dependency-management-for-testcontainers