### PR TITLE
Use bootTestRun to run the application locally

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,11 +41,9 @@ jobs:
         with:
           # shellcheck shell=sh
           # gradle's build task will build, assemble, and test the project.
-          # -Pno-testcontainers removes testcontainer runtime dependencies that are useful for developers.
-          # These aren't used in production because real services (ex, a database) on a real server area used instead.
           # Note that bootBuildImage builds the image, but it's not pushed anywhere.
           # In the real world, you would push it somewhere using the --publishImage argument to bootBuildImage.
-          arguments: build bootBuildImage -Pno-testcontainers
+          arguments: build bootBuildImage
       - name: upload build reports
         if: success() || failure() # always run even if the previous step fails
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,11 +73,9 @@ build and test:
     - |
       # shellcheck shell=sh
       # gradle's build task will build, assemble, and test the project.
-      # -Pno-testcontainers removes testcontainer runtime dependencies that are useful for developers.
-      # These aren't used in production because real services (ex, a database) on a real server area used instead.
       # Note that bootBuildImage builds the image, but it's not pushed anywhere.
       # In the real world, you would push it somewhere using the --publishImage argument to bootBuildImage.
-      ./gradlew build bootBuildImage -Pno-testcontainers
+      ./gradlew build bootBuildImage
   cache:
     key: "$CI_COMMIT_REF_NAME"
     policy: pull-push

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ And now go do the real work :-)
 ## Developer Setup
 This project requires Java 17 (or later).
 Import this Gradle project using your IDE of choice.
-Or, if you don't want to use an IDE, you can run the project from the command line: `./gradlew bootRun` The site will be accessible at [https://localhost:8443](https://localhost:8443)
+Or, if you don't want to use an IDE, you can run the project from the command line: `./gradlew bootTestRun` The site will be accessible at [https://localhost:8443](https://localhost:8443)
 
 Installing node and npm is not necessary. Gradle installs and manages node and npm; to use the gradle provided versions, run `./node` and `./npm` from the `frontend` directory.
 
@@ -96,7 +96,7 @@ The Project Lombok Eclipse integration must be setup. See the Eclipse instructio
 #### Running the Cypress Tests
 
 There are a few ways to run cypress tests locally:
-* Run the application, for example, by running `./gradlew bootRun`,then, from within the [`frontend`](frontend) directory, either run:
+* Run the application, for example, by running `./gradlew bootTestRun`,then, from within the [`frontend`](frontend) directory, either run:
     * `./npm run cypress-open` to open the Cypress GUI. This allows you to run individual tests in Chrome so you can watch them as they execute. This approach is great for debugging and visually verifying that your tests work.
     * `./npm run cypress-run` runs the entire test suite in a headless (Electron) browser all through the command line. This is an excellent option for just running the tests and seeing a pass/fail.
 * Run the application's tests with `./gradle test`. One of the tests run is [`CypressTest`](./src/test/java/com/integralblue/demo/jumpstart/CypressTest.java) which will run the Cypress tests. This approach is used by [`.gitlab-ci.yml`](.gitlab-ci.yml) when running continuous integration.
@@ -112,7 +112,7 @@ The configuration file at [`frontend/cypress.config.ts`](frontend/cypress.config
 #### Running the Lighthouse Tests
 
 There are a few ways to run cypress tests locally:
-* Run the application, for example, by running `./gradlew bootRun`,then, from within the [`frontend`](frontend) directory, run `./npm run lhci autorun --collect.startServerCommand=""`
+* Run the application, for example, by running `./gradlew bootTestRun`,then, from within the [`frontend`](frontend) directory, run `./npm run lhci autorun --collect.startServerCommand=""`
 * From within the [`frontend`](frontend) directory, run `./npm run lhci autorun` This command will start the application for you.
 * Run the application's tests with `./gradle test`. One of the tests run is [`LighthouseTest`](../src/test/java/com/integralblue/demo/jumpstart/LighthouseTest.java) which will run the Lighthouse tests. This approach is used by [`.gitlab-ci.yml`](.gitlab-ci.yml) when running continuous integration.
 

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 	annotationProcessor "org.hibernate.validator:hibernate-validator-annotation-processor"
 
 	developmentOnly "org.springframework.boot:spring-boot-devtools"
+	testImplementation "org.springframework.boot:spring-boot-devtools"
 
 	testImplementation "org.springframework.boot:spring-boot-starter-test"
 	testImplementation "org.springframework.security:spring-security-test"
@@ -50,11 +51,6 @@ dependencies {
 	testImplementation "org.testcontainers:testcontainers"
 	testImplementation "org.testcontainers:junit-jupiter"
 	testImplementation 'org.testcontainers:postgresql'
-	if (! project.hasProperty('no-testcontainers')) {
-		// testcontainers shouldn't be used in an actual, production environment (such as as on running in k8s, aws, etc)
-		// this property allows for the exclusion of testcontainers so "real" services can be used instead
-		runtimeOnly 'org.testcontainers:postgresql'
-	}
 }
 
 configurations {

--- a/frontend/lighthouserc.yml
+++ b/frontend/lighthouserc.yml
@@ -11,7 +11,7 @@ ci:
     numberOfRuns: 3
     url:
       - https://localhost:8443
-    startServerCommand: "cd .. && ./gradlew bootRun"
+    startServerCommand: "cd .. && ./gradlew bootTestRun"
     startServerReadyPattern: "Tomcat started on port"
     startServerReadyTimeout: 600000
     settings:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,5 +1,5 @@
 ---
-spring.config.import: application-testcontainers.yml,application-selfsigned.yml
+spring.config.import: application-selfsigned.yml
 
 # allow developers to more easily see these details to facilitate development
 # these details would be secured behind administrative credentials or unavailable entirely in production

--- a/src/main/resources/application-testcontainers.yml
+++ b/src/main/resources/application-testcontainers.yml
@@ -1,4 +1,0 @@
----
-# ?TC_TMPFS=/var/lib/postgresql/data:rw is a performance optimization to use a tmpfs for postgres data accelerating startup/runtime, see https://www.testcontainers.org/modules/databases/jdbc/
-internal.datasource.url: jdbc:tc:postgresql:${postgresql.version}:///?TC_TMPFS=/var/lib/postgresql/data:rw
-spring.datasource.url: ${internal.datasource.url}

--- a/src/test/resources/application-local.yml
+++ b/src/test/resources/application-local.yml
@@ -1,2 +1,2 @@
 ---
-spring.config.import: application-test.yml,application-testcontainers.yml,application-selfsigned.yml
+spring.config.import: application-test.yml,application-selfsigned.yml

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,2 +1,5 @@
 ---
 spring.liquibase.contexts: test
+# ?TC_TMPFS=/var/lib/postgresql/data:rw is a performance optimization to use a tmpfs for postgres data accelerating startup/runtime, see https://www.testcontainers.org/modules/databases/jdbc/
+internal.datasource.url: jdbc:tc:postgresql:${postgresql.version}:///?TC_TMPFS=/var/lib/postgresql/data:rw
+spring.datasource.url: ${internal.datasource.url}


### PR DESCRIPTION
bootTestRun is a cleaner solution than using a special profile.

See: https://docs.spring.io/spring-boot/docs/3.1.0/gradle-plugin/reference/htmlsingle/#running-your-application.using-a-test-main-class