### PR TITLE
Renovate: pin GitHub Action Digests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    "helpers:pinGitHubActionDigests",
     "config:base"
   ],
   "forkProcessing": "enabled",


### PR DESCRIPTION
A GitHub Action tag/version is mutable so, like docker images, it's a good idea to pin to a specific commit to ensure reproducibility.

See: https://docs.renovatebot.com/modules/manager/github-actions/