### PR TITLE
GitHub Actions: rename scan to checkov

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           name: jar
           path: build/libs/jumpstart.jar
-  scan:
+  checkov:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results


### PR DESCRIPTION
"checkov" is a more descriptive name for the job and it aligns with the equivalent GitLab CI job's name