### PR TITLE
Use the commit sha as the docker image tag for non-default branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:  # yamllint disable-line rule:truthy
   - push
 
 env:
-  IMAGE_NAME: ghcr.io/${{ github.repository }}:${{ ( github.ref_name == github.event.repository.default_branch ) && 'latest' || github.ref_name }}
+  IMAGE_NAME: ghcr.io/${{ github.repository }}:${{ ( github.ref_name == github.event.repository.default_branch ) && 'latest' || github.sha }}
 
 jobs:
   build:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,7 @@ workflow:
         IMAGE_NAME: "${CI_REGISTRY_IMAGE}:latest"
     - if: $CI_COMMIT_REF_NAME != $CI_DEFAULT_BRANCH
       variables:
-        IMAGE_NAME: "${CI_REGISTRY_IMAGE}:${CI_COMMIT_REF_NAME}"
+        IMAGE_NAME: "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}"
 
 codespell:
   stage: lint


### PR DESCRIPTION
Using the branch name as the tag can be problematic:
* The git branch name may not be a valid docker tag name
* A git branch may have commits added to it which can cause later workflow jobs to pick up a different image than expected.