### PR TITLE
Prefix ci container images with "ci-"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:  # yamllint disable-line rule:truthy
   - push
 
 env:
-  IMAGE_NAME: ghcr.io/${{ github.repository }}:${{ ( github.ref_name == github.event.repository.default_branch ) && 'latest' || github.sha }}
+  IMAGE_NAME: ghcr.io/${{ github.repository }}:${{ ( github.ref_name == github.event.repository.default_branch ) && 'latest' || format('ci-{0}', github.sha ) }}
 
 jobs:
   build:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,7 @@ workflow:
         IMAGE_NAME: "${CI_REGISTRY_IMAGE}:latest"
     - if: $CI_COMMIT_REF_NAME != $CI_DEFAULT_BRANCH
       variables:
-        IMAGE_NAME: "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}"
+        IMAGE_NAME: "${CI_REGISTRY_IMAGE}:ci-${CI_COMMIT_SHA}"
 
 codespell:
   stage: lint


### PR DESCRIPTION
Allows easier identification of ci images, facilitating cleanup.