### PR TITLE
Disable maven exclusion semantics in Spring Dependency Management Plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,11 @@ tasks.compileJava {
 	options.release = 17
 }
 
+dependencyManagement {
+	// workaround for https://github.com/spring-gradle-plugins/dependency-management-plugin/issues/365
+	applyMavenExclusions(false)
+}
+
 // Enable dependency locking: https://docs.gradle.org/current/userguide/dependency_locking.html
 // To achieve reproducible builds, it is necessary to lock versions of dependencies and transitive dependencies such that a build with the same inputs will always resolve the same module versions.
 // This is called dependency locking.

--- a/gradle.lockfile
+++ b/gradle.lockfile
@@ -108,6 +108,7 @@ org.osgi:org.osgi.service.prefs:1.1.2=sonarlintCoreClasspath
 org.osgi:osgi.annotation:8.0.1=sonarlintCoreClasspath
 org.ow2.asm:asm-commons:9.5=jacocoAnt
 org.ow2.asm:asm-tree:9.5=jacocoAnt
+org.ow2.asm:asm:9.0=sonarlintCoreClasspath
 org.ow2.asm:asm:9.3=testCompileClasspath,testRuntimeClasspath
 org.ow2.asm:asm:9.5=jacocoAnt
 org.postgresql:postgresql:42.6.0=productionRuntimeClasspath,runtimeClasspath,testRuntimeClasspath


### PR DESCRIPTION
Starting with Spring Dependency Management Plugin version 1.1.0, invalid POMs cause the plugin to fail. Unfortunately, Sonar has dependencies that have invalid POMs, and it doesn't appear that Sonar is going to change to use dependencies with valid POMs any time soon.

Therefore, in order to continuing using the name.remal.sonarlint plugin, there are only two options:
1. Downgrade Sonar to a version that has dependencies all with valid POMs. That could be done by adding a dependency on: `sonarlintCorePlugins("org.sonarsource.java:sonar-java-plugin:7.18.0.31443")` However, it's not ideal to be stuck on an old version for an indeterminate amount of time.
2. Disable Spring Dependency Management Plugin's new maven exclusion semantics. There doesn't appear to be a downside for this project in doing so.

See: https://github.com/spring-gradle-plugins/dependency-management-plugin/issues/365
See: https://community.sonarsource.com/t/sonar-java-plugin-has-dependencies-with-invalid-poms/96334/6