### PR TITLE
Remove spring dependency management workaround

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,11 +32,6 @@ tasks.compileJava {
 	options.release = 17
 }
 
-dependencyManagement {
-	// workaround for https://github.com/spring-gradle-plugins/dependency-management-plugin/issues/365
-	applyMavenExclusions(false)
-}
-
 // Enable dependency locking: https://docs.gradle.org/current/userguide/dependency_locking.html
 // To achieve reproducible builds, it is necessary to lock versions of dependencies and transitive dependencies such that a build with the same inputs will always resolve the same module versions.
 // This is called dependency locking.

--- a/gradle.lockfile
+++ b/gradle.lockfile
@@ -108,7 +108,6 @@ org.osgi:org.osgi.service.prefs:1.1.2=sonarlintCoreClasspath
 org.osgi:osgi.annotation:8.0.1=sonarlintCoreClasspath
 org.ow2.asm:asm-commons:9.5=jacocoAnt
 org.ow2.asm:asm-tree:9.5=jacocoAnt
-org.ow2.asm:asm:9.0=sonarlintCoreClasspath
 org.ow2.asm:asm:9.3=testCompileClasspath,testRuntimeClasspath
 org.ow2.asm:asm:9.5=jacocoAnt
 org.postgresql:postgresql:42.6.0=productionRuntimeClasspath,runtimeClasspath,testRuntimeClasspath


### PR DESCRIPTION
Remove workaround as the name.remal.sonarlint plugin now works around the issue.

See: https://github.com/spring-gradle-plugins/dependency-management-plugin/issues/365