### PR TITLE
Specify the lombok library version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,10 @@ dependencyLocking {
 	lockMode = LockMode.STRICT
 }
 
+lombok {
+    version = "1.18.28"
+}
+
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")


### PR DESCRIPTION
1.18.28 is the version currently used so this change is a no-op.

However, with the version specified, Renovate will now monitor for new versions.