### PR TITLE
Specify the jacoco library version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,10 @@ lombok {
     version = "1.18.30"
 }
 
+jacoco {
+    toolVersion = "0.8.9"
+}
+
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")


### PR DESCRIPTION
0.8.9 is the version currently used so this change is a no-op.

However, with the version specified, Renovate will now monitor for new versions.