### PR TITLE
Use bellsoft/liberica-openjdk-debian instead of eclipse-temurin

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -97,7 +97,7 @@ build and test:
     DOCKER_TLS_CERTDIR: ""
     DOCKER_USERNAME: "${CI_REGISTRY_USER}"
     DOCKER_PASSWORD: "${CI_REGISTRY_PASSWORD}"
-  image: eclipse-temurin:17.0.8_7-jdk@sha256:80c017af9fdd7913c7ffaffe398c1a5ca808d29befcc9a74c0f542b1b133f53c
+  image: bellsoft/liberica-openjdk-debian:17.0.8.1-1@sha256:d73fb30258a8a4b327710a5c37884cf297bed5bffd4580de6ca8f66a2b0d779f
   before_script:
     - |
       # shellcheck shell=sh


### PR DESCRIPTION
Spring Boot's bootBuildImage uses the liberica buildpack. It's more consistent to use the same JDK distribution for runtime and build / test, so use liberica as the build job's image.