### PR TITLE
renovate: nodeVersion uses double quotes

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -46,7 +46,7 @@
     },
     {
       "fileMatch": ["^build.gradle$"],
-      "matchStrings": ["nodeVersion *= *'(?<currentValue>.+?)';?\n?"],
+      "matchStrings": ["nodeVersion *= *"(?<currentValue>.+?)";?\n?"],
       "depNameTemplate": "node",
       "datasourceTemplate": "docker"
     }


### PR DESCRIPTION
With the migration of build.gradle to kotlin in 2ed15bc , the nodeVersion was changed to use double quotes (") from single quotes ('), therefore the renovate configuration needs to be updated.