### PR TITLE
renovate.json: build.gradle is now build.gradle.kts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,8 +27,8 @@
       "datasourceTemplate": "npm"
     },
     {
-      "description": "Update docker references in build.gradle",
-      "fileMatch": ["^build.gradle$"],
+      "description": "Update docker references in build.gradle.kts",
+      "fileMatch": ["^build.gradle.kts$"],
       "matchStrings": [
         "\"(?<depName>(?:gcr\\.io|docker\\.io)\\/[^:]+?):(?<currentValue>[^@]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?\""
       ],
@@ -45,7 +45,7 @@
       "versioningTemplate": "docker"
     },
     {
-      "fileMatch": ["^build.gradle$"],
+      "fileMatch": ["^build.gradle.kts$"],
       "matchStrings": ["nodeVersion *= *\"(?<currentValue>.+?)\";?\n?"],
       "depNameTemplate": "node",
       "datasourceTemplate": "docker"


### PR DESCRIPTION
With the migration of build.gradle to kotlin in 2ed15bc, build.gradle is now build.gradle.kts