### PR TITLE
scap: Install git as a workaround

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,11 @@ jobs:
           # shellcheck shell=sh
           set -eu
           apk add curl docker jq openscap-docker npm gcompat unzip
+
+          # Install git to workaround https://github.com/sinonjs/sinon/issues/2557
+          # Remove when sinon 16.1.2 (or later) is released, or when using MITRE_SAF_VERSION that includes https://github.com/mitre/saf/pull/1919
+          apk add git
+
           npm install -g "@microsoft/sarif-multitool@${MICROSOFT_SARIF_MULTITOOL_VERSION}"
           npm install -g "@mitre/saf@${MITRE_SAF_VERSION}"
           mkdir -p "${SSG_DIR}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -152,6 +152,11 @@ scap:
       set -eu
       printf "\e[0Ksection_start:%s:prerequisites[collapsed=true]\r\e[0KInstalling prerequisites...\n" "$(date +%s)"
       apk add curl docker openscap-docker npm gcompat unzip
+
+      # Install git to workaround https://github.com/sinonjs/sinon/issues/2557
+      # Remove when sinon 16.1.2 (or later) is released, or when using MITRE_SAF_VERSION that includes https://github.com/mitre/saf/pull/1919
+      apk add git
+
       npm install -g "@microsoft/sarif-multitool@${MICROSOFT_SARIF_MULTITOOL_VERSION}"
       npm install -g "@mitre/saf@${MITRE_SAF_VERSION}"
       mkdir ssg


### PR DESCRIPTION
Sinon erroneously currently requires git to be installed: https://github.com/sinonjs/sinon/issues/2557

However, sinon is a testing tool which should even be used anyways: https://github.com/mitre/saf/pull/1919