### PR TITLE
scap: specify version of sinon instead of installing git

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,13 +109,10 @@ jobs:
           # shellcheck shell=sh
           set -eu
           apk add curl docker jq openscap-docker npm gcompat unzip
-
-          # Install git to workaround https://github.com/sinonjs/sinon/issues/2557
-          # Remove when sinon 16.1.2 (or later) is released, or when using MITRE_SAF_VERSION that includes https://github.com/mitre/saf/pull/1919
-          apk add git
-
           npm install -g "@microsoft/sarif-multitool@${MICROSOFT_SARIF_MULTITOOL_VERSION}"
-          npm install -g "@mitre/saf@${MITRE_SAF_VERSION}"
+          # Specify the sinon version to use.
+          # Remove sinon from this line when sinon 16.1.2 (or later) is released, or when using MITRE_SAF_VERSION that includes https://github.com/mitre/saf/pull/1919
+          npm install -g sinon@16.1.0 "@mitre/saf@${MITRE_SAF_VERSION}"
           mkdir -p "${SSG_DIR}"
           curl "https://github.com/ComplianceAsCode/content/releases/download/v${SCAP_SECURITY_GUIDE_VERSION}/scap-security-guide-${SCAP_SECURITY_GUIDE_VERSION}.zip" -Lso "${SSG_DIR}/ssg.zip"
           unzip "${SSG_DIR}/ssg.zip" -d "${SSG_DIR}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -152,13 +152,10 @@ scap:
       set -eu
       printf "\e[0Ksection_start:%s:prerequisites[collapsed=true]\r\e[0KInstalling prerequisites...\n" "$(date +%s)"
       apk add curl docker openscap-docker npm gcompat unzip
-
-      # Install git to workaround https://github.com/sinonjs/sinon/issues/2557
-      # Remove when sinon 16.1.2 (or later) is released, or when using MITRE_SAF_VERSION that includes https://github.com/mitre/saf/pull/1919
-      apk add git
-
       npm install -g "@microsoft/sarif-multitool@${MICROSOFT_SARIF_MULTITOOL_VERSION}"
-      npm install -g "@mitre/saf@${MITRE_SAF_VERSION}"
+      # Specify the sinon version to use.
+      # Remove sinon from this line when sinon 16.1.2 (or later) is released, or when using MITRE_SAF_VERSION that includes https://github.com/mitre/saf/pull/1919
+      npm install -g sinon@16.1.0 "@mitre/saf@${MITRE_SAF_VERSION}"
       mkdir ssg
       ssgdir="ssg"
       curl "https://github.com/ComplianceAsCode/content/releases/download/v${SCAP_SECURITY_GUIDE_VERSION}/scap-security-guide-${SCAP_SECURITY_GUIDE_VERSION}.zip" -Lso "${ssgdir}/ssg.zip"


### PR DESCRIPTION
Specifying the version of sinon to use is preferable to having git installed because having a reliance on git could have unintended side effects.