### PR TITLE
renovate: find updates in Java tests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,18 @@
     "helpers:pinGitHubActionDigests",
     "config:base"
   ],
+  "ignorePresets": [
+    ":ignoreModulesAndTests"
+  ],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/examples/**",
+    "**/__tests__/**",
+    "**/tests/**",
+    "**/__fixtures__/**"
+  ],
   "forkProcessing": "enabled",
   "pinDigests": true,
   "platformAutomerge": true,


### PR DESCRIPTION
Renovate's ":ignoreModulesAndTests" preset (which is included by "config:base") ignores paths matching `**/test/**` which matches `src/test/java`, therefore Renovate doesn't check the the Java test files for updates. In this project, those Java test files contain docker image references that should be checked for updates.

To address this issue, the ":ignoreModulesAndTests" is skipped and the `ignorePaths` value is specified with the same value as that provided by ":ignoreModulesAndTests" minus `**/test/**` .

See: https://docs.renovatebot.com/presets-default/#ignoremodulesandtests