### PR TITLE
Renovate:  Handle sometimes present "v" in version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,7 @@
       "fileMatch": ["\\.yml$"],
       "matchStrings": ["SARIF_CONVERTER_VERSION *: *\"(?<currentValue>.+?)\""],
       "depNameTemplate": "ignis-build/sarif-converter",
+      "extractVersionTemplate": "^v?(?<version>.*)$",
       "datasourceTemplate": "gitlab-releases"
     },
     {


### PR DESCRIPTION
Sometimes releases from some data sources (GitHub/GitLab tags/releases) may have a "v" prefix. That prefix should not be included in the version value Renovate uses to generate pull requests.