### PR TITLE
gradle/gradle-build-action replaced by gradle/actions/setup-gradle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
           distribution: "liberica"
           cache: "gradle"
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@4c39dd82cd5e1ec7c6fa0173bb41b4b6bb3b86ff # v3
+        uses: gradle/actions/setup-gradle@db19848a5fa7950289d3668fb053140cf3028d43 # v3
       - name: Build with Gradle
         run: |
           # shellcheck shell=sh


### PR DESCRIPTION
See: https://github.com/gradle/actions/blob/eb13cf7170810b90071fe0f748f939620b067fdf/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle