### PR TITLE
Address computedNodeDir deprecation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,7 +96,7 @@ gradleLint {
 */
 
 sonarLint {
-	sonarProperty("sonar.nodejs.executable", project.provider { "${node.computedNodeDir.get()}/bin/node"}) // configure Node.js executable path via `sonar.nodejs.executable` Sonar property
+	sonarProperty("sonar.nodejs.executable", project.provider { "${node.resolvedNodeDir})/bin/node"}) // configure Node.js executable path via `sonar.nodejs.executable` Sonar property
 }
 
 // reproducible builds
@@ -188,7 +188,7 @@ node {
 
 tasks.register("nodeDir") {
 	dependsOn(tasks.nodeSetup)
-	println(node.computedNodeDir.get())
+	println(node.resolvedNodeDir)
 }
 
 val npm_run_build by tasks.registering(NpmTask::class) {


### PR DESCRIPTION
The resolved/computed node directory and platform are stored in `resolvedNodeDir` and `resolvedPlatform` on `NodeExtension`

See: https://github.com/node-gradle/gradle-node-plugin/blob/6.0.0/CHANGELOG.md#version-600-2023-08-15