### PR TITLE
When running frontend only, proxy /actuator

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   server: {
     port: 3000,
     proxy: {
-      "^/(api)": {
+      "^/(api|actuator)/": {
         target: "https://localhost:8443",
       },
     },


### PR DESCRIPTION
When using `npm start` to run the frontend only, have vite proxy /actuator/*