### PR TITLE
For sonarlint, set nodeJsExecutable

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,7 +96,9 @@ gradleLint {
 */
 
 sonarLint {
-	sonarProperty("sonar.nodejs.executable", project.provider { "${node.resolvedNodeDir})/bin/node"}) // configure Node.js executable path via `sonar.nodejs.executable` Sonar property
+	nodeJs {
+		nodeJsExecutable = project.provider{ file("${node.resolvedNodeDir.get()}/bin/node") }
+	}
 }
 
 // reproducible builds


### PR DESCRIPTION
In sonarlint 4.0.0, new nodejs configuration settings were added.

See: https://github.com/remal-gradle-plugins/sonarlint/releases/tag/v4.0.0