### PR TITLE
Improve error messaging when shellcheck enounters unexpected yaml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,14 @@ jobs:
           git ls-files --exclude='*.sh' --ignored -c -z | xargs -0r shellcheck -P SCRIPTDIR -x
           git ls-files --exclude='.github/**/*.yml' --ignored -c | while IFS= read -r file; do
            yq eval '.[] | select(tag=="!!map").[].steps.[].run | select(. != null ) | path | ".[\"" + join("\"].[\"") + "\"]"' "${file}" | while IFS= read -r selector; do
+              set -e
               script=$(yq eval "${selector}" "${file}")
+              status=$?
+              set +e
+              if [ $status -ne 0 ]; then
+                >&2 printf "\nError getting the contents of the selector %s in the file %s:\n\nThe YAML may be malformed." "${selector}" "${file}"
+                exit 1
+              fi
               if ! printf '%s' "${script}" | shellcheck -x -; then
                   >&2 printf "\nError in %s in the script specified in %s:\n%s\n" "${file}" "${selector}" "${script}"
                   exit 1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,7 +63,14 @@ shellcheck:
         while [ "$documentIndex" -lt "$documentCount" ]; do
           true $((documentIndex=documentIndex+1))
           yq eval 'select(documentIndex == '${documentIndex}') | .[] | select(tag=="!!map") | (.before_script,.script,.after_script) | select(. != null ) | path | "select(documentIndex == '${documentIndex}') | .[\"" + join("\"].[\"") + "\"]"' "${file}" | while IFS= read -r selector; do
+            set -e
             script=$(yq eval "${selector} | join(\"${newline}\")" "${file}")
+            status=$?
+            set +e
+            if [ $status -ne 0 ]; then
+              >&2 printf "\nError getting the contents of the selector %s in the file %s:\n\nThe YAML may be malformed." "${selector}" "${file}"
+              exit 1
+            fi
             if ! printf '%s' "${script}" | shellcheck -x -; then
               >&2 printf "\nError in %s in the script specified in %s:\n%s\n" "${file}" "${selector}" "${script}"
               exit 1


### PR DESCRIPTION
If eval of the selector fails, display a nice error message