### PR TITLE
FixedUsernamePasswordSecurityConfiguration: suppress sonarlint finding

### DIFF
--- a/src/main/java/com/integralblue/demo/jumpstart/security/FixedUsernamePasswordSecurityConfiguration.java
+++ b/src/main/java/com/integralblue/demo/jumpstart/security/FixedUsernamePasswordSecurityConfiguration.java
@@ -32,6 +32,7 @@ public class FixedUsernamePasswordSecurityConfiguration {
 			.build();
 	}
 
+	@SuppressWarnings("java:S6437") /// These credentials are only for testing and should be hardcoded
 	@Bean
 	public InMemoryUserDetailsManager userDetailsService() {
 		@SuppressWarnings("deprecation")


### PR DESCRIPTION
These credentials are only for testing and should be hardcoded.