### PR TITLE
JumpstartApplicationTests: remove unnecessary import

### DIFF
--- a/src/test/java/com/integralblue/demo/jumpstart/JumpstartApplicationTests.java
+++ b/src/test/java/com/integralblue/demo/jumpstart/JumpstartApplicationTests.java
@@ -6,8 +6,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import com.integralblue.demo.jumpstart.JumpstartApplication;
-
 @SpringBootTest
 /* default */ class JumpstartApplicationTests {
 	@Autowired


### PR DESCRIPTION
Same package classes are always implicitly imported.