### PR TITLE
Sonarlint tasks depend on nodeSetup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,6 +95,14 @@ gradleLint {
 }
 */
 
+tasks.sonarlintMain {
+	dependsOn(tasks.nodeSetup)
+}
+
+tasks.sonarlintTest {
+	dependsOn(tasks.nodeSetup)
+}
+
 sonarLint {
 	nodeJs {
 		nodeJsExecutable = project.provider{ file("${node.resolvedNodeDir.get()}/bin/node") }


### PR DESCRIPTION
Sonarlint uses node so it needs to depend on nodeSetup so node is installed and available when it runs.