### PR TITLE
buildDir is deprecated

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -184,7 +184,7 @@ tasks.jacocoTestCoverageVerification {
 	}
 }
 
-val generatedFrontendResources = "$buildDir/generated-resources"
+val generatedFrontendResources = "${layout.buildDirectory}/generated-resources"
 val frontend = "$projectDir/frontend"
 
 val testsExecutedMarkerName = "${projectDir}/.tests.executed"


### PR DESCRIPTION
Addresses warning `'getter for buildDir: File!' is deprecated. Deprecated in Java`

See: https://docs.gradle.org/current/userguide/upgrading_version_8.html#project_builddir