### PR TITLE
Use builder-jammy-buildpackless-tiny as buildpack builder

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -132,7 +132,7 @@ tasks.bootBuildImage {
 		// make sure to configure Renovate to keep these image references up to date.
 		// if these image references are not kept up to date, any security issues discovered within them will never be fixed.
 		// Use a tiny builder and run image (which produce a distroless-like image) to reduce both image size and attack surface.
-		builder = "docker.io/paketobuildpacks/builder-jammy-tiny:0.0.304@sha256:34726bc71e2da02423a853db7233d488832a6c72ac1942cff6e59f9041644004"
+		builder = "docker.io/paketobuildpacks/builder-jammy-buildpackless-tiny:0.0.158@sha256:57d53619cabc2182c8833b1c3964fab894bb3163f84a76f51d113527969aeace"
 		runImage = "docker.io/paketobuildpacks/run-jammy-tiny:0.2.55@sha256:2d87eb82a91fda704539eb12ffd9b178c44e05a937dad947faabb1341173602b"
 		buildpacks = listOf(
 			"gcr.io/paketo-buildpacks/ca-certificates:3.8.6@sha256:420c96eac964f520b9b8fee74c3511c357d3e917dc1161f61c75dc2905eeb49b",


### PR DESCRIPTION
builder-jammy-buildpackless-tiny doesn't include any buildpacks compared to builder-jammy-tiny which does.

Since this project always specifies the buildpacks to use, the buildpackless builder makes more sense and provides more flexibility should a buildpack need to be removed or replaced.