### PR TITLE
fix nodeDir task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -198,7 +198,7 @@ node {
 
 tasks.register("nodeDir") {
 	dependsOn(tasks.nodeSetup)
-	println(node.resolvedNodeDir)
+	println(node.resolvedNodeDir.get())
 }
 
 val npm_run_build by tasks.registering(NpmTask::class) {


### PR DESCRIPTION
Output the node directory instead of `extension 'node' property 'resolvedNodeDir'`