### PR TITLE
Get buildpacks from docker.io, not gcr.io

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -131,12 +131,12 @@ tasks.bootBuildImage {
 		builder = "docker.io/paketobuildpacks/builder-jammy-buildpackless-tiny:0.0.168@sha256:00939b329b37cec7dda99ceb7a5a0b241093b5d6f32d5bc64453ef88076d7669"
 		runImage = "docker.io/paketobuildpacks/run-jammy-tiny:0.2.61@sha256:f8e55c2672eaf71347f65ad699b655472985454206dcd200e35e435333930b84"
 		buildpacks = listOf(
-			"gcr.io/paketo-buildpacks/ca-certificates:3.10.0@sha256:a657ca4ac593317aebf26fcf3a0c95a1fe677f4e7c9a61ca49ea8fe6ecc8fef2",
-			"gcr.io/paketo-buildpacks/bellsoft-liberica:11.2.0@sha256:e4dc0c554d3d24b7f91b3fd53b2977901d164a74c5fe1c2b61c16a27997f16d3",
-			"gcr.io/paketo-buildpacks/syft:2.10.0@sha256:2655871794637683c56b81db835ab3be32c34e98bc273ba5f65e6a3e378c7381",
-			"gcr.io/paketo-buildpacks/executable-jar:6.13.0@sha256:41d5a82645610491af05e01a4d1fa1287045ff21ffec90d62251d1747e24827c",
-			"gcr.io/paketo-buildpacks/dist-zip:5.10.0@sha256:856d49cfa67bb892eb5209544cc6b42914cdc828755bcc53ad67eeee41033446",
-			"gcr.io/paketo-buildpacks/spring-boot:5.33.0@sha256:b9ace562dd30d8cbeefde5c488ee9f8741c8ed75a1e171bb92d9d0c0bc0b9881",
+			"docker.io/paketobuildpacks/ca-certificates:3.10.0@sha256:a657ca4ac593317aebf26fcf3a0c95a1fe677f4e7c9a61ca49ea8fe6ecc8fef2",
+			"docker.io/paketobuildpacks/bellsoft-liberica:11.2.0@sha256:e4dc0c554d3d24b7f91b3fd53b2977901d164a74c5fe1c2b61c16a27997f16d3",
+			"docker.io/paketobuildpacks/syft:2.10.0@sha256:2655871794637683c56b81db835ab3be32c34e98bc273ba5f65e6a3e378c7381",
+			"docker.io/paketobuildpacks/executable-jar:6.13.0@sha256:41d5a82645610491af05e01a4d1fa1287045ff21ffec90d62251d1747e24827c",
+			"docker.io/paketobuildpacks/dist-zip:5.10.0@sha256:856d49cfa67bb892eb5209544cc6b42914cdc828755bcc53ad67eeee41033446",
+			"docker.io/paketobuildpacks/spring-boot:5.33.0@sha256:b9ace562dd30d8cbeefde5c488ee9f8741c8ed75a1e171bb92d9d0c0bc0b9881",
 		)
 	}
 }


### PR DESCRIPTION
Buildpacks are no longer available from gcr.io

See: https://blog.paketo.io/posts/paketo-gcr-registry-sunset/