### PR TITLE
test: Use the lhci docker image for LighthouseTest

### DIFF
--- a/frontend/lighthouserc.yml
+++ b/frontend/lighthouserc.yml
@@ -6,6 +6,7 @@ ci:
     puppeteerLaunchOptions:
       args:
         - '--no-sandbox'
+        - '--disable-setuid-sandbox'
         - '--headless'
         - '--ignore-certificate-errors'
     numberOfRuns: 3


### PR DESCRIPTION
Instead of install lighthouse and puppeteer in an image, use the lhci client image which already has all tools preinstalled.

See: https://googlechrome.github.io/lighthouse-ci/docs/recipes/docker-client/